### PR TITLE
Let users specify a function as click_function

### DIFF
--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -106,18 +106,44 @@ export class Renderer {
     return this;
   }
 
+  _click_function_from_string() {
+    return Function("datum", this.scatterplot.prefs.click_function)
+  }
+
+  _click_function_matches_prefs() {
+    if (this._click_function_type == "string" && this._click_function == this._click_function_from_string()) {
+      return true
+    } else if (this._click_function_type == "function" && this._click_function == this.scatterplot.prefs.click_function) {
+      return true
+    }
+
+    return false
+  }
+
   set click_function(f) {
-    this._current_click_function_string = this.scatterplot.prefs.click_function;
-    this._click_function = Function("datum", this._current_click_function_string)
+    if (typeof(this.scatterplot.prefs.click_function) == "function") {
+      this._click_function_type = "function"
+      this._click_function = this.scatterplot.prefs.click_function
+    } else if (typeof(this.scatterplot.prefs.click_function) == "string") {
+      this._click_function_type = "string"
+      this._click_function = this._click_function_from_string()
+    } else {
+      // Make sure _click_function is always defined, but use a no-op if we
+      // don't recognize the input type.
+      console.log('Unrecognized click_function type; should be string or function.')
+      this._click_function_type = null
+      this._click_function = (function() {})
+    }
   }
 
   get click_function() {
-    if (this._current_click_function_string && this._current_click_function_string === this.scatterplot.prefs.click_function) {
-      return this._click_function;
+    // If the click function is unset or doesn't match the current preferences,
+    // set it before returning it..
+    if ( !(this._click_function) || !(this._click_function_matches_prefs()) ) {
+      this.click_function = this.scatterplot.prefs.click_function
     }
-    this._current_click_function_string = this.scatterplot.prefs.click_function;
-    this._click_function = Function("datum", this.scatterplot.prefs.click_function)
-    return this._click_function;
+
+    return this._click_function
   }
 
   * initialize() {
@@ -129,5 +155,5 @@ export class Renderer {
 }
 
 export class CanvasRenderer extends Renderer {
-  
+
 }


### PR DESCRIPTION
Fixes #11 .

I've tested this by hand by using a string, a function, and an integer as prefs.click_function, and they all worked as expected. But you should definitely give it a read.