### PR TITLE
Fix mouseout behavior

### DIFF
--- a/src/interaction.ts
+++ b/src/interaction.ts
@@ -85,9 +85,9 @@ export default class Zoom {
           .style('padding', '10px')
           .style('background', 'ivory')
           .style('opacity', 0.75),
-        (exit) => exit,
         (update) => update
           .html((d) => this.tooltip_html(d.data)),
+        (exit) => exit.call((e) => e.remove())
       );
 
     els
@@ -99,7 +99,7 @@ export default class Zoom {
   }
 
   get tooltip_html() {
-    // a function that 
+    // a function that
     if (this._tooltip_html_function === undefined) {
       return label_from_point
     } else {
@@ -181,14 +181,9 @@ export default class Zoom {
         },
       ] : [];
 
-      if (!d) return;
-
       const { x_, y_ } = this.scales();
 
-      if (annotations.length) {
-        // When a function is "annotated", this gets called.
-        this.html_annotation(annotations);
-      }
+      this.html_annotation(annotations);
 
       const labelSet = select('#deepscatter-svg')
         .selectAll('circle.label')


### PR DESCRIPTION
In the previous iteration, when moving from a dot with data to a space
without data, the cleanup event didn't fire. This meant that a dot would
be frozen in its hover state while the mouse went elsewhere (until it
hovered over another dot). This ensures that the annotation function --
where the exit/remove logic lives -- actually gets fired when we LEAVE
a dot (and are hovering over nothing).