### PR TITLE
fix: minor tweaks and improvements to tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "lodash-es": "^4.17.21",
     "lodash.merge": "^4.6.2"
   },
-  "deprecated": false,
   "devDependencies": {
     "@playwright/test": "^1.23.1",
     "@types/d3": "^7.4.0",

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,2 @@
+declare module '*.frag';
+declare module '*.vert';

--- a/src/regl_rendering.ts
+++ b/src/regl_rendering.ts
@@ -5,11 +5,8 @@ import { range, sum } from 'd3-array';
 import unpackFloat from 'glsl-read-float';
 import Zoom, { window_transform } from './interaction';
 import { Renderer } from './rendering';
-//@ts-ignore
 import gaussian_blur from './glsl/gaussian_blur.frag';
-//@ts-ignore
 import vertex_shader from './glsl/general.vert';
-//@ts-ignore
 import frag_shader from './glsl/general.frag';
 import { AestheticSet } from './AestheticSet';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,15 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "lib": ["es2020"],
+    // "lib": ["es2020"],
     "module": "esnext",
     "moduleResolution": "node",
     "esModuleInterop": true,
     "noUnusedLocals": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es2020"
+    "target": "es2020",
+    "isolatedModules": true
   },
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Recommended"


### PR DESCRIPTION
## What This PR Does

Minor tweaks to address erroneous type errors caused by malformed typescript configuration.

- `tsconfig.json`: remove `lib` field and add `target` field. `lib` is automatically inferred from `target`. Additionally, overriding it was causing other necessary libraries to be excluded (e.g. `DOM`), thus producing type errors.
- `globals.d.ts`: add module declarations for GLSL shaders. This solves errors caused by importing them. 
- `regl_rendering.ts`: removed `@ts-ignore` comments for GLSL shader imports. They are no longer necessary due to the above change.
- `package.json`: remove `deprecated` field. This is not a [valid package.json property](https://docs.npmjs.com/cli/v8/configuring-npm/package-json)