### PR TITLE
Improve Typing for Aesthetics and Transforms

### DIFF
--- a/src/Dataset.ts
+++ b/src/Dataset.ts
@@ -45,7 +45,7 @@ export abstract class Dataset<T extends Tile> {
   
   map<U>(callback : (tile: T) => U, after = false) : U[] {
     const results : U[] = [];
-    this.visit((d : T) => { results.push(callback(d)); }, after = after);
+    this.visit((d : T) => { results.push(callback(d)); }, after);
     return results;
   }
 

--- a/src/regl_rendering.ts
+++ b/src/regl_rendering.ts
@@ -126,7 +126,7 @@ export class ReglRenderer extends Renderer {
     const { prefs } = this;
     const { transform } = this.zoom;
     const { aes_to_buffer_num, buffer_num_to_variable, variable_to_buffer_num } = this.allocate_aesthetic_buffers();
-    console.log(prefs.arrow_table);
+    // console.log(prefs.arrow_table);
     const props = {
     // Copy the aesthetic as a string.
       aes: { encoding: this.aes.encoding },

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export type ConstantChannel = {
   constant : number;
 };
 
+export type Transform = 'log' | 'linear' | 'sqrt' | 'literal';
 
 /**
  * A channel represents the information necessary to map a single dimension
@@ -56,7 +57,7 @@ export interface BasicChannel {
    * 'literal' maps in the implied dataspace set by 'x', 'y', while
    * 'linear' transforms the data by the range and domain.
   */
-  transform? : 'log' | 'linear' | 'sqrt' | 'literal';
+  transform? : Transform;
   // The domain over which the data extends 
   domain? : [number, number];
   // The range into which to map the data.


### PR DESCRIPTION
- refactor: move `Transform` type `Aesthetic.ts` to `types.ts` and export it
- refactor: use `Transform` type in channel type definitions
- refactor(aesthetics): make `dim` method strongly typed
- refactor(aesthetics): make `store` and `scales` strongly typed
- 