### PR TITLE
Feature -- Allow for multiple scatterplots

### DIFF
--- a/dist/deepscatter.js
+++ b/dist/deepscatter.js
@@ -5348,6 +5348,7 @@ class Zoom {
     this.renderers = /* @__PURE__ */ new Map();
     this.scatterplot = plot;
     this.renderers = /* @__PURE__ */ new Map();
+    this.plotId = plot.plotId
   }
   attach_tiles(tiles) {
     this.tileSet = tiles;
@@ -5431,7 +5432,7 @@ class Zoom {
       ] : [];
       const { x_, y_ } = this.scales();
       this.html_annotation(annotations);
-      select("#deepscatter-svg").selectAll("circle.label").data(data, (d_) => d_.ix).join(
+      select(`#deepscatter-svg-${this.plotId}`).selectAll("circle.label").data(data, (d_) => d_.ix).join(
         (enter) => enter.append("circle").attr("class", "label").attr("stroke", "#110022").attr("r", 12).attr("fill", (dd) => this.renderers.get("regl").aes.dim("color").current.apply(dd)).attr("cx", (datum2) => x_(x_aes.value_for(datum2))).attr("cy", (datum2) => y_(y_aes.value_for(datum2))),
         (update) => update.attr("fill", (dd) => this.renderers.get("regl").aes.dim("color").current.apply(dd)),
         (exit) => exit.call((e) => e.remove())
@@ -18226,7 +18227,6 @@ class ReglRenderer extends Renderer {
     const { prefs } = this;
     const { transform } = this.zoom;
     const { aes_to_buffer_num, buffer_num_to_variable, variable_to_buffer_num } = this.allocate_aesthetic_buffers();
-    console.log(prefs.arrow_table);
     const props = {
       aes: { encoding: this.aes.encoding },
       colors_as_grid: 0,
@@ -28226,10 +28226,10 @@ const base_elements = [
   }
 ];
 class Scatterplot {
-  constructor(selector2, width, height) {
+  constructor(selector2, width, height, plotId = '1') {
     this.bound = false;
     if (selector2 !== void 0) {
-      this.bind(selector2, width, height);
+      this.bind(selector2, width, height, plotId);
     }
     this.width = width;
     this.height = height;
@@ -28246,15 +28246,17 @@ class Scatterplot {
     };
     this.d3 = { select };
   }
-  bind(selector2, width, height) {
-    this.div = select(selector2).selectAll("div.deepscatter_container").data([1]).join("div").attr("class", "deepscatter_container").style("position", "absolute");
+  bind(selector2, width, height, plotId) {
+    this.plotId = plotId;
+    this.base_elements = base_elements.map((element) => {return {...element, id: `${element.id}-${plotId}`}})
+    this.div = select(selector2).selectAll(`div.deepscatter_container-${plotId}`).data([1]).join("div").attr("class", `deepscatter_container-${plotId}`).style("position", "absolute");
     if (this.div.empty()) {
       console.error(selector2);
       throw "Must pass a valid div selector";
     }
     this.elements = [];
-    for (const d of base_elements) {
-      const container = this.div.append("div").attr("id", `container-for-${d.id}`).style("position", "absolute").style("top", 0).style("left", 0).style("pointer-events", d.id === "deepscatter-svg" ? "auto" : "none");
+    for (const d of this.base_elements) {
+      const container = this.div.append("div").attr("id", `container-for-${d.id}`).style("position", "absolute").style("top", 0).style("left", 0).style("pointer-events", d.id === `deepscatter-svg-${plotId}` ? "auto" : "none");
       container.append(d.nodetype).attr("id", d.id).attr("width", width || window.innerWidth).attr("height", height || window.innerHeight);
       this.elements.push(container);
     }
@@ -28271,15 +28273,15 @@ class Scatterplot {
     }
     await this._root.ready;
     this._renderer = new ReglRenderer(
-      "#container-for-webgl-canvas",
+      `#container-for-webgl-canvas-${this.plotId}`,
       this._root,
       this
     );
-    this._zoom = new Zoom("#deepscatter-svg", this.prefs, this);
+    this._zoom = new Zoom(`#deepscatter-svg-${this.plotId}`, this.prefs, this);
     this._zoom.attach_tiles(this._root);
     this._zoom.attach_renderer("regl", this._renderer);
     this._zoom.initialize_zoom();
-    const bkgd = select("#container-for-canvas-2d-background").select("canvas");
+    const bkgd = select(`#container-for-canvas-2d-background-${this.plotId}`).select("canvas");
     const ctx = bkgd.node().getContext("2d");
     ctx.fillStyle = prefs.background_color || "rgba(133, 133, 111, .8)";
     ctx.fillRect(0, 0, window.innerWidth * 2, window.innerHeight * 2);


### PR DESCRIPTION
What this PR does
* Allows for `plotId` parameter in Scatterplot initialization
* PlotId is incorporated into canvas, container, and svg classes and Id's
* Parameter includes default value to maintain existing functionality
* Removes console.log on line 18229 as it was running indefinitely in Storybook

Example of two plots on same page
![image](https://user-images.githubusercontent.com/71410916/187299844-bc350f49-b0ba-4fd4-9c9a-2636905935cf.png)

Example of changed classes and ids
![image](https://user-images.githubusercontent.com/71410916/187300006-687c6944-2030-44c2-8e78-faf1c1a03883.png)


