### PR TITLE
Allow Points to be Dragged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ dist/tiles
 test-results/
 playwright-report/
 dist/tiles/*
+
+tiles
+tmp.csv
+*.feather

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deepscatter",
-  "version": "2.3.3",
+  "version": "2.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "deepscatter",
-      "version": "2.3.3",
+      "version": "2.4.1",
       "license": "MIT",
       "dependencies": {
         "apache-arrow": "^9.0.0",
@@ -14,6 +14,7 @@
         "d3-array": "^3.2.0",
         "d3-color": "^3.1.0",
         "d3-contour": "^4.0.0",
+        "d3-drag": "^3.0.0",
         "d3-ease": "^3.0.1",
         "d3-fetch": "^3.0.1",
         "d3-format": "^3.1.0",
@@ -36,6 +37,7 @@
       "devDependencies": {
         "@playwright/test": "^1.25.0",
         "@types/d3": "^7.4.0",
+        "@types/d3-drag": "^3.0.1",
         "@types/d3-geo": "^3.0.2",
         "@types/d3-selection": "^3.0.3",
         "@types/lodash.merge": "^4.6.7",
@@ -352,8 +354,9 @@
     },
     "node_modules/@types/d3-drag": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.1.tgz",
+      "integrity": "sha512-o1Va7bLwwk6h03+nSM8dpaGEYnoIG19P0lKqlic8Un36ymh9NSkNFX1yiXMKNMx8rJ0Kfnn2eovuFaL6Jvj0zA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/d3-selection": "*"
       }
@@ -1160,7 +1163,8 @@
     },
     "node_modules/d3-drag": {
       "version": "3.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-selection": "3"
@@ -4874,6 +4878,8 @@
     },
     "@types/d3-drag": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.1.tgz",
+      "integrity": "sha512-o1Va7bLwwk6h03+nSM8dpaGEYnoIG19P0lKqlic8Un36ymh9NSkNFX1yiXMKNMx8rJ0Kfnn2eovuFaL6Jvj0zA==",
       "dev": true,
       "requires": {
         "@types/d3-selection": "*"
@@ -5419,6 +5425,8 @@
     },
     "d3-drag": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
       "requires": {
         "d3-dispatch": "1 - 3",
         "d3-selection": "3"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "d3-array": "^3.2.0",
     "d3-color": "^3.1.0",
     "d3-contour": "^4.0.0",
+    "d3-drag": "^3.0.0",
     "d3-ease": "^3.0.1",
     "d3-fetch": "^3.0.1",
     "d3-format": "^3.1.0",
@@ -64,6 +65,7 @@
   "devDependencies": {
     "@playwright/test": "^1.25.0",
     "@types/d3": "^7.4.0",
+    "@types/d3-drag": "^3.0.1",
     "@types/d3-geo": "^3.0.2",
     "@types/d3-selection": "^3.0.3",
     "@types/lodash.merge": "^4.6.7",

--- a/src/Dataset.ts
+++ b/src/Dataset.ts
@@ -85,6 +85,7 @@ export abstract class Dataset<T extends Tile> {
       }
     }
   }
+
   /**
    * 
    * @param ix The index of the point to get.
@@ -104,6 +105,32 @@ export abstract class Dataset<T extends Tile> {
     });
     return matches;
   }
+
+  /**
+   * 
+   * @param ix The index of the point to get.
+   * @returns 
+   */
+  updatePoint(ix : number, data: StructRowProxy) : StructRowProxy[] {
+    const matches : StructRowProxy[] = [];
+    this.visit((tile : T) => {
+      if (!(tile.ready && tile.record_batch && tile.min_ix <= ix && tile.max_ix >= ix)) {
+        return;
+      }
+      const mid = bisectLeft([...tile.record_batch.getChild('ix').data[0].values], ix);
+      const val = tile.record_batch.get(mid);
+      if (val?.ix === ix) {
+        console.log('setting datum', ix, 'to', data.toJSON());
+        console.log(data)
+        console.log('old datum', val.toJSON());
+        tile.record_batch.set(ix, data);
+        console.log('datum after update:', tile.record_batch.get(ix)?.toJSON());
+        matches.push(val);
+      }
+    });
+    return matches;
+  }
+
 
 
   get tileWorker() {

--- a/src/Dataset.ts
+++ b/src/Dataset.ts
@@ -107,54 +107,6 @@ export abstract class Dataset<T extends Tile> {
     return matches;
   }
 
-  /**
-   * 
-   * @param ix The index of the point to get.
-   * @returns 
-   */
-  updatePointCoordinates(ix : number, coords: { x: number, y: number }) : StructRowProxy[] {
-    const matches : StructRowProxy[] = [];
-    this.visit((tile : T) => {
-      if (!(tile.ready && tile.record_batch && tile.min_ix <= ix && tile.max_ix >= ix)) {
-        return;
-      }
-      const mid = bisectLeft([...tile.record_batch.getChild('ix').data[0].values], ix);
-      const val = tile.record_batch.get(mid);
-      assert(val);
-      if (val.ix === ix) {
-        console.log(`before set: (${val.x}, ${val.y})`, val);
-        // const [x, y] = ['x', 'y'].map(name => {
-        //   const child: Vector<Float32> | null = tile.record_batch.getChild(name);
-        //   assert(child, `record batch has no ${name} child`);
-        //   child.
-        //   tile.record_batch.setChild()
-        //   return child;
-        // });
-        for (const name of ['x', 'y'] as const) {
-          const child: Vector<Float32> | null = tile.record_batch.getChild(name);
-          assert(child, `record batch has no ${name} child`);
-          
-          // child.toArray()
-          // const array = new Float32Array(child.data[0].values);
-          const array = child.toArray();
-          console.log(`before set: ${array[mid]}`);
-          array[mid] = coords[name];
-          console.log(`after set: ${array[mid]}`);
-          tile.record_batch.setChild(name, makeVector(array));
-        }
-
-        // x.data[0].values.set([coords.x], mid);
-        // y.data[0].values.set([coords.y], mid);
-        const post = tile.record_batch.get(mid);
-        console.log(`after set: (${post.x}, ${post.y})`, post);
-        // x.set
-
-        matches.push(val);
-      }
-    });
-    return matches;
-  }
-
   get tileWorker() {
     const NUM_WORKERS = 4;
     if (this._tileworkers.length > 0) {

--- a/src/deepscatter.ts
+++ b/src/deepscatter.ts
@@ -40,6 +40,7 @@ export default class Scatterplot {
   public prefs : APICall;
   ready : Promise<void>;
   public click_handler : ClickFunction;
+  public drag_handler : DragFunction; 
   public tooltip_handler : TooltipHTML;
 
   constructor(selector : string, width : number, height: number) {
@@ -52,6 +53,7 @@ export default class Scatterplot {
     // Unresolvable.
     this.ready = Promise.resolve();
     this.click_handler = new ClickFunction(this);
+    this.drag_handler = new DragFunction(this);
     this.tooltip_handler = new TooltipHTML(this);
     this.prefs = {
       zoom_balance: 0.35,
@@ -244,12 +246,22 @@ export default class Scatterplot {
     /* PUBLIC see set tooltip_html */
     return this.tooltip_handler.f;
   }
+
   set click_function(func) {
     this.click_handler.f = func;
   }
+
   get click_function() {
     /* PUBLIC see set click_function */
     return this.click_handler.f;
+  }
+
+  set drag_function(func) {
+    this.drag_handler.f = func;
+  }
+
+  get drag_function() {
+    return this.drag_handler.f
   }
 
   async plotAPI(prefs : APICall) {
@@ -257,6 +269,11 @@ export default class Scatterplot {
     if (prefs.click_function) {
       this.click_function = Function('datum', prefs.click_function);
     }
+
+    if (prefs.drag_function) {
+      this.drag_function = Function('datum', prefs.drag_function);
+    }
+
     if (prefs.tooltip_html) {
       this.tooltip_html = Function('datum', prefs.tooltip_html);
     }
@@ -426,6 +443,13 @@ abstract class SettableFunction<FuncType> {
 }
 
 class ClickFunction extends SettableFunction<void> {
+  //@ts-ignore bc https://github.com/microsoft/TypeScript/issues/48125
+  default(datum : StructRowProxy) {
+    console.log({ ...datum });
+  }
+}
+
+class DragFunction extends SettableFunction<void> {
   //@ts-ignore bc https://github.com/microsoft/TypeScript/issues/48125
   default(datum : StructRowProxy) {
     console.log({ ...datum });

--- a/src/deepscatter.ts
+++ b/src/deepscatter.ts
@@ -277,7 +277,7 @@ export default class Scatterplot {
   }
 
   get drag_function() {
-    return this.drag_handler.f
+    return this.drag_handler.f;
   }
 
   async plotAPI(prefs : APICall) {

--- a/src/interaction.ts
+++ b/src/interaction.ts
@@ -182,6 +182,7 @@ export default class Zoom {
       ] : [];
 
       const { x_, y_ } = this.scales();
+      const { scatterplot } = this;
 
       this.html_annotation(annotations);
 
@@ -189,6 +190,8 @@ export default class Zoom {
         .selectAll('circle.label')
         .data(data, (d_) => d_.ix)
         .join(
+
+          // Enter
           (enter) => enter
             .append('circle')
             .call(drag<SVGCircleElement, StructRowProxy>()
@@ -213,8 +216,11 @@ export default class Zoom {
                   .attr('cx', x_(datum.x))
                   .attr('cy', y_(datum.y));
               })
-              .on('end', function on_drag_end(this: SVGCircleElement, event: CircleDragEvent, datum) {
+              .on('end', function on_drag_end(this: SVGCircleElement, event: CircleDragEvent, datum: StructRowProxy) {
                 select(this).attr('cursor', 'grab');
+                // renderer.render_points(renderer.props);
+                renderer.render_all(renderer.props);
+                scatterplot.drag_function(datum);
               }))
             .attr('cursor', 'grab')
             .attr('class', 'label')
@@ -223,12 +229,16 @@ export default class Zoom {
             .attr('fill', (dd) => this.renderers.get('regl').aes.dim('color').current.apply(dd))
             .attr('cx', (datum) => x_(x_aes.value_for(datum)))
             .attr('cy', (datum) => y_(y_aes.value_for(datum))),
+
+          // Update
           (update) => update
             .attr('fill', (dd) => this.renderers.get('regl').aes.dim('color').current.apply(dd)),
+
+          // Exit
           (exit) => exit.call((e) => e.remove())
         )
         .on('click', (ev, dd) => {
-          this.scatterplot.click_function(dd);
+          scatterplot.click_function(dd);
         });
     });
   }

--- a/src/interaction.ts
+++ b/src/interaction.ts
@@ -11,7 +11,7 @@ import type { Renderer } from './rendering';
 import type QuadtreeRoot from './tile';
 import { ReglRenderer } from './regl_rendering';
 import Scatterplot from './deepscatter';
-import { StructRow, StructRowProxy } from 'apache-arrow';
+import { Float32, makeData, StructRow, StructRowProxy } from 'apache-arrow';
 import type { Dataset } from './Dataset'
 import type { Tile } from './tile'
 
@@ -232,7 +232,9 @@ export default class Zoom {
 
                 console.log(`datum[ix: ${datum.ix}] (${datum.x}, ${datum.y})`);
                 console.log(datum);
-                self.tileSet.updatePoint(datum.ix, datum);
+                // datum.x = makeData<Float32>({ type: new Float32(), data: [datum.x]});
+                // self.tileSet.updatePoint(datum.ix, datum);
+                self.tileSet?.updatePointCoordinates(datum.ix, { x: datum.x, y: datum.y });
                 renderer.render_all(renderer.props);
                 scatterplot.drag_function(datum);
               }))

--- a/src/interaction.ts
+++ b/src/interaction.ts
@@ -223,22 +223,14 @@ export default class Zoom {
                 select(this)
                   .attr('cx', x_(datum.x))
                   .attr('cy', y_(datum.y));
+
+                const tile = self.scatterplot._root.root_tile as QuadTile;
+                tile.visit_at_point(datum.ix, tile => tile.needs_rerendering('x', 'y'));
               })
 
               // Drag end
               .on('end', function on_drag_end(this: SVGCircleElement, event: CircleDragEvent, datum: StructRowProxy) {
                 select(this).attr('cursor', 'grab');
-                // renderer.render_points(renderer.props);
-
-                console.log(`datum[ix: ${datum.ix}] (${datum.x}, ${datum.y})`);
-                console.log(datum);
-
-                const tile = self.scatterplot._root.root_tile as QuadTile;
-
-                // console.log(`findPoint before: ${tile.findPoint(datum.ix) || 'not found'}`);
-                tile.updatePoint(datum.ix, datum);
-                // console.log(`findPoint after: ${tile.findPoint(datum.ix) || 'not found'}`);
-                renderer.remake_renderer();
                 renderer.render_all(renderer.props);
                 scatterplot.drag_function(datum);
               }))

--- a/src/interaction.ts
+++ b/src/interaction.ts
@@ -12,8 +12,8 @@ import type QuadtreeRoot from './tile';
 import { ReglRenderer } from './regl_rendering';
 import Scatterplot from './deepscatter';
 import { Float32, makeData, StructRow, StructRowProxy } from 'apache-arrow';
-import type { Dataset } from './Dataset'
-import type { Tile } from './tile'
+import type { Dataset } from './Dataset';
+import type { QuadTile, Tile } from './tile';
 
 
 export default class Zoom {
@@ -232,9 +232,13 @@ export default class Zoom {
 
                 console.log(`datum[ix: ${datum.ix}] (${datum.x}, ${datum.y})`);
                 console.log(datum);
-                // datum.x = makeData<Float32>({ type: new Float32(), data: [datum.x]});
-                // self.tileSet.updatePoint(datum.ix, datum);
-                self.tileSet?.updatePointCoordinates(datum.ix, { x: datum.x, y: datum.y });
+
+                const tile = self.scatterplot._root.root_tile as QuadTile;
+
+                // console.log(`findPoint before: ${tile.findPoint(datum.ix) || 'not found'}`);
+                tile.updatePoint(datum.ix, datum);
+                // console.log(`findPoint after: ${tile.findPoint(datum.ix) || 'not found'}`);
+                renderer.remake_renderer();
                 renderer.render_all(renderer.props);
                 scatterplot.drag_function(datum);
               }))

--- a/src/regl_rendering.ts
+++ b/src/regl_rendering.ts
@@ -126,7 +126,6 @@ export class ReglRenderer extends Renderer {
     const { prefs } = this;
     const { transform } = this.zoom;
     const { aes_to_buffer_num, buffer_num_to_variable, variable_to_buffer_num } = this.allocate_aesthetic_buffers();
-    console.log(prefs.arrow_table);
     const props = {
     // Copy the aesthetic as a string.
       aes: { encoding: this.aes.encoding },

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -2,11 +2,12 @@
 import { select } from 'd3-selection';
 import { min } from 'd3-array';
 import type Scatterplot from './deepscatter';
-import type { Tileset } from './tile';
+import type { Tile, Tileset } from './tile';
 import type { APICall } from './types';
 import type Zoom from './interaction';
 import type { AestheticSet } from './AestheticSet';
 import { timer, Timer } from 'd3-timer';
+import type { Dataset } from './Dataset';
 
 abstract class PlotSetting {
   abstract start: number;
@@ -119,7 +120,7 @@ export class Renderer {
   public _zoom : Zoom;
   public _initializations : Promise<any>[];
   public render_props : RenderProps;
-  constructor(selector, tileSet, scatterplot) {
+  constructor(selector: string, tileSet: Dataset<Tile>, scatterplot: Scatterplot) {
     this.scatterplot = scatterplot;
     this.holder = select(selector);
     this.canvas = select(this.holder.node().firstElementChild);
@@ -190,13 +191,13 @@ export class Renderer {
     return max_points * k * k / point_size_adjust / point_size_adjust;
   }
 
-  visible_tiles() {
+  visible_tiles(): Tile[] {
     // yield the currently visible tiles based on the zoom state
     // and a maximum index passed manually.
     const { max_ix } = this;
     const { tileSet } = this;
     // Materialize using a tileset method.
-    let all_tiles;
+    let all_tiles: Tile[];
     const natural_display = this.aes.dim('x').current.field == 'x' &&
       this.aes.dim('y').current.field == 'y' &&
       this.aes.dim('x').last.field == 'x' &&

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,28 +1,34 @@
-import { extent } from 'd3-array';
+// import { extent } from 'd3-array';
 
-// eslint-disable-next-line import/prefer-default-export
-export function encodeFloatsRGBArange(values, array) {
-  // Rescale a number into the range [0, 1e32]
-  // so that it can be passed to the four components of a texture.
-  values = values.flat();
-
-  const [min, max] = extent(values);
-
-  if (array === undefined) {
-    array = new Uint32Array(values.length);
+export function assert(cond: unknown, message?: string): asserts cond {
+  if (!cond) {
+    throw new Error(message ?? 'Assertion failed');
   }
-
-  const scale_size = (2 ** 32) / (max - min);
-
-  let i = 0;
-
-  for (const value of values) {
-    array[i] = (value - min) * scale_size;
-    i += 1;
-  }
-
-  return {
-    extent: [min, max],
-    array: new Uint8Array(array.buffer),
-  };
 }
+// TODO: This function is unused and appears broken. Commenting out for now.
+// eslint-disable-next-line import/prefer-default-export
+// export function encodeFloatsRGBArange(values, array) {
+//   // Rescale a number into the range [0, 1e32]
+//   // so that it can be passed to the four components of a texture.
+//   values = values.flat();
+
+//   const [min, max] = extent(values);
+
+//   if (array === undefined) {
+//     array = new Uint32Array(values.length);
+//   }
+
+//   const scale_size = (2 ** 32) / (max - min);
+
+//   let i = 0;
+
+//   for (const value of values) {
+//     array[i] = (value - min) * scale_size;
+//     i += 1;
+//   }
+
+//   return {
+//     extent: [min, max],
+//     array: new Uint8Array(array.buffer),
+//   };
+// }


### PR DESCRIPTION
# What This PR Does
This PR allows users to click and drag any point on the screen. I would record a Loom to demonstrate dragging behavior but recording is bugged out for me right now. As points are dragged, both the SVG circle and the corresponding dot on the scatterplot are updated. Releasing the mouse invokes a `DragHandler` function, which is similar to a `ClickHandler`.

## Additional Features
* New public methods for `QuadTile`:
  - `visit_at_point(ix, callback)`: Finds a tile that contains a desired point and invokes a callback function. Uses a breadth-first search to check the targeted tile and it's children 
  - `find_point(ix)`: Finds a point with the target index. Consumes `visit_at_point`.
  - `update_point(ix, new_point)`: Updates the data for the point at `ix`. Consumes `visit_at_point`.
* Add `assert` utility. Behaves similarly to node's assert, but does not require a polyfill 